### PR TITLE
add modal type

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -18,16 +18,11 @@ export class AppComponent {
     const modal = this.myModalService.get(name);
 
     if (!modal) {
-      console.error('No modal named %s', name);
+      // console.error('No modal named %s', name);
       return;
     }
 
     modal.button2Label = 'terms.button';
     modal.toggle();
   }
-
-  cancelReservation() {
-    console.log('ssss');
-  }
-
 }

--- a/src/app/components/nt-modal/nt-modal.component.ts
+++ b/src/app/components/nt-modal/nt-modal.component.ts
@@ -43,9 +43,9 @@ export class NtModalComponent implements OnInit {
 
     this.myModals.set(this.name, this);
   }
-
   initIconModal(typeModal: string) {
     typeModal = typeModal.toLowerCase();
+
     switch (typeModal) {
       case 'information':
         this.iconModal = this.iconModals.info;
@@ -61,7 +61,6 @@ export class NtModalComponent implements OnInit {
 
   clickOverlay(event: Event) {
     const target = (event.target as HTMLElement);
-    console.log(event)
 
     if (target.classList.contains('modal-component') || target.classList.contains('modal-component__content')) {
       this.toggle();


### PR DESCRIPTION
fixes #2 

##result this PR

default style
![image](https://user-images.githubusercontent.com/5290381/56676812-1b8a9680-668d-11e9-80b6-7d8d9560eb48.png)

warning style
![image (1)](https://user-images.githubusercontent.com/5290381/56676893-44129080-668d-11e9-81ab-fc3888e73b2a.png)

danger style
![image (2)](https://user-images.githubusercontent.com/5290381/56676944-5c82ab00-668d-11e9-8066-fe47fbaa41da.png)

information style
![image (3)](https://user-images.githubusercontent.com/5290381/56677024-98b60b80-668d-11e9-98dd-8efd01690bae.png)

how change a style
when we change the modal style, you have to choose between 4 types (danger, default, information, warning) in `_typeModal_` option

exemple code:
```
<app-nt-modal name="test_modal"
              typeModal="information"
              title="modal"
              button2Label="{{ 'profile.cancel_reservation_button' }}"
              (button2)="cancelReservation()"
              maxWidth="600px"
              [autoClose]="true">
  <p>
    {{ 'profile.cancel_reservation_text_1' }}
  </p>
  <p>
    {{ 'profile.cancel_reservation_text_2' }}
  </p>
</app-nt-modal>
```


